### PR TITLE
add useDebounce

### DIFF
--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+import useTimeout from "./useTimeout";
+
+/**
+ * This hook allows you to debounce any fast changing value. The debounced
+ * value will only reflect the latest value when the useDebounce hook has not
+ * been called for the specified time period.
+ *
+ * @param value a value to debounce
+ * @param ms The milliseconds duration duration to debounce the value
+ */
+export default function useDebounce<V extends any>(value: V, delay: number): V {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  const timeout = useTimeout();
+
+  useEffect(() => {
+    timeout.set(() => {
+      setDebouncedValue(value);
+    }, delay);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
Adds a `useDebounce` hook that debounces a value a specified amount. This implementation was taken from https://usehooks.com/useDebounce/ and adapted to use this library's `useTimeout` hook.