### PR TITLE
fix: set crossOrigin prior to src

### DIFF
--- a/src/useImage.ts
+++ b/src/useImage.ts
@@ -46,8 +46,8 @@ export default function useImage(
 
     if (typeof imageOrUrl === 'string') {
       image = new Image()
-      image.src = imageOrUrl
       if (crossOrigin) image.crossOrigin = crossOrigin
+      image.src = imageOrUrl
     } else {
       image = imageOrUrl
 


### PR DESCRIPTION
I think setting the src variable kicks off the request for the image without setting the CORS attribute 