### PR TITLE
fix: Allow React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "conventionalCommits": true
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@4c/babel-preset": "^7.3.3",


### PR DESCRIPTION
Should resolve the problem found in https://github.com/react-bootstrap/react-bootstrap/issues/5540