### PR TITLE
feat: add useDebouncedCallback and useDebouncedState

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react'
+import useTimeout from './useTimeout'
+
+/**
+ * Creates a debounced function that will invoke the input function after the
+ * specified delay.
+ *
+ * @param fn a function that will be debounced
+ * @param delay The milliseconds delay before invoking the function
+ */
+export default function useDebouncedCallback<
+  TCallback extends (...args: any[]) => any
+>(fn: TCallback, delay: number): TCallback {
+  const timeout = useTimeout()
+  return useCallback(
+    (...args: any[]) => {
+      timeout.set(() => {
+        fn(...args)
+      }, delay)
+    },
+    [fn, delay],
+  ) as any
+}

--- a/src/useDebouncedState.ts
+++ b/src/useDebouncedState.ts
@@ -1,0 +1,27 @@
+import { useState, Dispatch, SetStateAction } from 'react'
+import useDebouncedCallback from './useDebouncedCallback'
+
+/**
+ * Similar to `useState`, except the setter function is debounced by
+ * the specified delay.
+ *
+ * ```ts
+ * const [value, setValue] = useDebouncedState('test', 500)
+ *
+ * setValue('test2')
+ * ```
+ *
+ * @param initialState initial state value
+ * @param delay The milliseconds delay before a new value is set
+ */
+export default function useDebouncedState<T>(
+  initialState: T,
+  delay: number,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState(initialState)
+  const debouncedSetState = useDebouncedCallback<Dispatch<SetStateAction<T>>>(
+    setState,
+    delay,
+  )
+  return [state, debouncedSetState]
+}

--- a/test/useDebouncedCallback.test.tsx
+++ b/test/useDebouncedCallback.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import useDebouncedCallback from '../src/useDebouncedCallback'
+
+describe('useDebouncedCallback', () => {
+  it('should return a function that debounces input callback', () => {
+    jest.useFakeTimers()
+    const spy = jest.fn()
+
+    let debouncedFn;
+
+    function Wrapper() {
+      debouncedFn = useDebouncedCallback(spy, 500)
+      return <span />
+    }
+
+    mount(<Wrapper />)
+
+    debouncedFn(1)
+    debouncedFn(2)
+    debouncedFn(3)
+    expect(spy).not.toHaveBeenCalled()
+
+    jest.runOnlyPendingTimers()
+    
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(3)
+  })
+})

--- a/test/useDebouncedState.test.tsx
+++ b/test/useDebouncedState.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import useDebouncedState from '../src/useDebouncedState'
+
+describe('useDebouncedState', () => {
+  it('should return a function that debounces input callback', () => {
+    jest.useFakeTimers()
+
+    let outerSetValue
+
+    function Wrapper() {
+      const [value, setValue] = useDebouncedState(0, 500)
+      outerSetValue = setValue
+      return <span>{value}</span>
+    }
+
+    const wrapper = mount(<Wrapper />)
+    expect(wrapper.text()).toBe('0')
+
+    outerSetValue((cur: number) => cur + 1)
+    outerSetValue((cur: number) => cur + 1)
+    outerSetValue((cur: number) => cur + 1)
+    outerSetValue((cur: number) => cur + 1)
+    outerSetValue((cur: number) => cur + 1)
+
+    expect(wrapper.text()).toBe('0')
+
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    
+    expect(wrapper.text()).toBe('1')
+  })
+})


### PR DESCRIPTION
`useDebouncedCallback` allows you to create a function that is debounced by x milliseconds
`useDebouncedState` is like `useState`, except the setter is a debounced function