### PR TITLE
feat(useIntersectionObserver): add more performant overload

### DIFF
--- a/src/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver.ts
@@ -2,30 +2,61 @@ import { useState } from 'react'
 
 import useStableMemo from './useStableMemo'
 import useEffect from './useIsomorphicEffect'
+import useEventCallback from './useEventCallback'
 
 /**
  * Setup an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) on
- * a DOM Element.
+ * a DOM Element. This overload does not trigger component updates when receiving new
+ * entries. This allows for finer grained performance optimizations by the consumer.
+ *
+ * @param element The DOM element to observe
+ * @param callback A listener for intersection updates.
+ * @param init IntersectionObserver options
+ */
+function useIntersectionObserver<TElement extends Element>(
+  element: TElement | null | undefined,
+  callback: IntersectionObserverCallback,
+  options: IntersectionObserverInit,
+): void
+/**
+ * Setup an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) on
+ * a DOM Element that returns it's entries as they arrive.
  *
  * @param element The DOM element to observe
  * @param init IntersectionObserver options
  */
-export default function useIntersectionObserver<TElement extends Element>(
+function useIntersectionObserver<TElement extends Element>(
   element: TElement | null | undefined,
-  { threshold, root, rootMargin }: IntersectionObserverInit = {},
-) {
+  options: IntersectionObserverInit,
+): IntersectionObserverEntry[]
+function useIntersectionObserver<TElement extends Element>(
+  element: TElement | null | undefined,
+  callbackOrOptions: IntersectionObserverCallback | IntersectionObserverInit,
+  maybeOptions?: IntersectionObserverInit,
+): void | IntersectionObserverEntry[] {
+  let callback: IntersectionObserverCallback | undefined
+  let options: IntersectionObserverInit
+  if (typeof callbackOrOptions === 'function') {
+    callback = callbackOrOptions
+    options = maybeOptions || {}
+  } else {
+    options = callbackOrOptions || {}
+  }
+  const { threshold, root, rootMargin } = options
   const [entries, setEntry] = useState<IntersectionObserverEntry[] | null>(null)
+
+  const handler = useEventCallback(callback || setEntry)
 
   const observer = useStableMemo(
     () =>
       typeof IntersectionObserver !== 'undefined' &&
-      new IntersectionObserver(entries => setEntry(entries), {
+      new IntersectionObserver(handler, {
         threshold,
         root,
         rootMargin,
       }),
 
-    [root, rootMargin, threshold && JSON.stringify(threshold)],
+    [handler, root, rootMargin, threshold && JSON.stringify(threshold)],
   )
 
   useEffect(() => {
@@ -38,5 +69,7 @@ export default function useIntersectionObserver<TElement extends Element>(
     }
   }, [observer, element])
 
-  return entries || []
+  return callback ? undefined : entries || []
 }
+
+export default useIntersectionObserver

--- a/src/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver.ts
@@ -6,6 +6,17 @@ import useEventCallback from './useEventCallback'
 
 /**
  * Setup an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) on
+ * a DOM Element that returns it's entries as they arrive.
+ *
+ * @param element The DOM element to observe
+ * @param init IntersectionObserver options
+ */
+function useIntersectionObserver<TElement extends Element>(
+  element: TElement | null | undefined,
+  options: IntersectionObserverInit,
+): IntersectionObserverEntry[]
+/**
+ * Setup an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) on
  * a DOM Element. This overload does not trigger component updates when receiving new
  * entries. This allows for finer grained performance optimizations by the consumer.
  *
@@ -18,17 +29,6 @@ function useIntersectionObserver<TElement extends Element>(
   callback: IntersectionObserverCallback,
   options: IntersectionObserverInit,
 ): void
-/**
- * Setup an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) on
- * a DOM Element that returns it's entries as they arrive.
- *
- * @param element The DOM element to observe
- * @param init IntersectionObserver options
- */
-function useIntersectionObserver<TElement extends Element>(
-  element: TElement | null | undefined,
-  options: IntersectionObserverInit,
-): IntersectionObserverEntry[]
 function useIntersectionObserver<TElement extends Element>(
   element: TElement | null | undefined,
   callbackOrOptions: IntersectionObserverCallback | IntersectionObserverInit,

--- a/src/useMutationObserver.ts
+++ b/src/useMutationObserver.ts
@@ -17,7 +17,7 @@ function isDepsEqual(
  * Observe mutations on a DOM node or tree of DOM nodes.
  * Depends on the `MutationObserver` api.
  *
- * ```ts
+ * ```tsx
  * const [element, attachRef] = useCallbackRef(null);
  *
  * useMutationObserver(element, { subtree: true }, (records) => {
@@ -42,7 +42,7 @@ function useMutationObserver(
  * Observe mutations on a DOM node or tree of DOM nodes.
  * use a `MutationObserver` and return records as the are received.
  *
- * ```ts
+ * ```tsx
  * const [element, attachRef] = useCallbackRef(null);
  *
  * const records = useMutationObserver(element, { subtree: true });


### PR DESCRIPTION
This adds an overload that avoids a state update, and therefor a re-render if a callback is passed.