### PR TITLE
fix: minor typo in useCommittedRef

### DIFF
--- a/src/useCommittedRef.ts
+++ b/src/useCommittedRef.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react'
 /**
  * Creates a `Ref` whose value is updated in an effect, ensuring the most recent
  * value is the one rendered with. Generally only required for Concurrent mode usage
- * where previous work in `render()` may be discarded befor being used.
+ * where previous work in `render()` may be discarded before being used.
  *
  * This is safe to access in an event handler.
  *


### PR DESCRIPTION
As titled, this PR aims to fix a minor typo in useCommittedRef