### PR TITLE
fix: adjust useMounted to work with strict effects

### DIFF
--- a/src/useMounted.ts
+++ b/src/useMounted.ts
@@ -23,11 +23,11 @@ import { useRef, useEffect } from 'react'
 export default function useMounted(): () => boolean {
   const mounted = useRef(true)
   const isMounted = useRef(() => mounted.current)
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mounted.current = true
+    return () => {
       mounted.current = false
-    },
-    [],
-  )
+    }
+  }, [])
   return isMounted.current
 }


### PR DESCRIPTION
Fix for downsteam: https://github.com/react-bootstrap/react-bootstrap/issues/6284 .

React 18 introduces a new [mount -> unmount -> mount](https://github.com/reactwg/react-18/discussions/19) pattern, which breaks `useMounted` and by extension `useSafeState` hook. I don't think there's a way to test this unfortunately(although if you've got any ideas let me know), but I've tested it locally and it fixes the issue that i've linked above.