### PR TITLE
feat: add exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,18 @@
   "main": "lib/cjs/index.js",
   "types": "lib/cjs/index.d.ts",
   "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./esm/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./*": {
+      "types": "./esm/*.d.ts",
+      "import": "./esm/*.js",
+      "require": "./cjs/*.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jquense/react-common-hooks.git"


### PR DESCRIPTION
Adds `exports` field so TS projects using `node16` as the `moduleResolution` will work.