### PR TITLE
Introduce useStateFromProps hook

### DIFF
--- a/src/useStateFromProps.ts
+++ b/src/useStateFromProps.ts
@@ -1,0 +1,34 @@
+import { useState, DependencyList } from 'react'
+
+/** 
+ * Allows user to reset or adjust the state on a prop change.
+ * Functions similar to React's `useState`,
+ * but re-evaluates the state whenever the dependency array encounters a change.
+ * 
+ * Source: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+ *
+ * ```js
+ * const [state, setState] = useStateFromProps(()=>propCount, [propCount])
+ *
+ * ```
+ *
+ * @param reducer The props to state evaluation function
+ */
+export default function useStateFromProps<TState = unknown>(
+  reducer: (state: TState | null) =>  TState,
+  deps: DependencyList
+): [TState, (state: TState | null) => void] {
+  const [state, setState] = useState<TState>(() => reducer(null));
+  const [prevDeps, setPrevDeps] = useState<DependencyList>(deps);
+
+  const isDepsLengthChanged = !prevDeps || prevDeps.length !== deps.length;
+  const isDepsChanged =
+    isDepsLengthChanged || deps.some((prop, pIdx) => prop !== prevDeps[pIdx]);
+
+  if (isDepsChanged) {
+    setPrevDeps(deps);
+    setState((prevState) => reducer(prevState));
+  }
+
+  return [state, setState];
+}


### PR DESCRIPTION
Create a Hook to derive state from props, that allows the state to be re-evaluated whenever props are changed.

**Source**: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes

**Use-Case**: A Counter Component that initializes the count based on the `count` prop & runs independently. But the Counter Component's count resets whenever the `count` prop changes.

**CodeSandbox**: https://codesandbox.io/s/usestatefromprops-8qk4gt